### PR TITLE
Remove pytest as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ keywords = [
     'EBNF', 'SXML', 'XML'
 ]
 dependencies = [
-    "pytest>=7.4.4",
     "regex>=2024.4.16",
 ]
 


### PR DESCRIPTION
From what I can tell by running `git grep pytest` there is no part of the DHParser module that imports pytest, and that it is only used for running tests in the development or build environment.